### PR TITLE
Resolve Safari war from #50 & #52

### DIFF
--- a/public/script/Event.js
+++ b/public/script/Event.js
@@ -1,6 +1,17 @@
 export class Event {
     constructor(partial) {
         Object.assign(this, partial);
-        this.date = new Date(this.date.replace(/(\..*|\+.*)/, ""));
+
+        // Fix Safari bug with ISO 8601 format
+        // <time>Z      - works
+        // <time>±hh    - invalid -> translate to <time>±hh:00
+        // <time>±hhmm  - invalid -> translate to <time>±hh:mm
+        // <time>±hh:mm - works
+        // https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators, https://stackoverflow.com/a/49138448/1641372
+        let safariComplaintDate = this.date
+            .replace(/([-+])(\d\d)$/, '$1$2:00')
+            .replace(/([-+])(\d\d)(\d\d)$/, '$1$2:$3');
+
+        this.date = new Date(safariComplaintDate);
     }
 }

--- a/public/script/Helpers.js
+++ b/public/script/Helpers.js
@@ -5,23 +5,12 @@ export function htmlEscape(input) {
 }
 
 export function formatDate(date) {
-    let timezone = 'Europe/Prague';
-    if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) { // safari workaround
-        timezone = 'UTC';
-    }
-    return new Intl.DateTimeFormat('cs', {
+    return new Intl.DateTimeFormat('cs-CZ', {
         weekday: 'long',
         month: 'numeric',
         day: 'numeric',
         hour: 'numeric',
         minute: 'numeric',
-        timeZone: timezone,
+        timeZone: 'Europe/Prague',
     }).format(date);
 }
-
-export function pad(n, width) {
-    n = n + '';
-    return n.length >= width ? n : new Array(width - n.length + 1).join('0') + n;
-}
-
-export const days = ['pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota', 'neděle'];


### PR DESCRIPTION
- Fix buggy workaround about Safari's ISO 8601 format bug from 08c5b814f9921f61e80254aacbda4a0d6fe4bfbc
- Remove smelly workaround from #52
- Clean unused code form #50
- Use `cz-CZ` localization code instead of basic subtype `cs`

Prosím o otestování před vypuštěním na produkci